### PR TITLE
fix: Remove duplicates from manual entries

### DIFF
--- a/src/save.js
+++ b/src/save.js
@@ -3,7 +3,10 @@ const { log } = require('cozy-konnector-libs')
 const { Q } = require('cozy-client')
 
 const { findSavedTripByDates } = require('./queries')
-const { keepOnlyNewTrips } = require('./utils')
+const {
+  keepOnlyNewTrips,
+  keepMoreRecentTripsWhenDuplicates
+} = require('./utils')
 const { VENDOR, GEOJSON_DOCTYPE, ACCOUNT_DOCTYPE } = require('./const')
 
 const client = cozyClient.new
@@ -50,7 +53,14 @@ async function updateTripsWithManualEntries(
     tripsToUpdate.push(newTrip)
   }
   if (tripsToUpdate.length > 0) {
-    await client.saveAll(tripsToUpdate)
+    const tripsNoDuplicates = keepMoreRecentTripsWhenDuplicates(tripsToUpdate)
+    for (const trip of tripsNoDuplicates) {
+      log(
+        'info',
+        `Update trip ${trip._id} from ${trip.startDate} to ${trip.endDate}`
+      )
+      await client.save(trip)
+    }
   }
 }
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,6 +1,5 @@
-const { chunk } = require('lodash')
+const { chunk, differenceWith, sortBy, uniqBy } = require('lodash')
 const { findSavedTripByDates } = require('./queries')
-const { differenceWith } = require('lodash')
 
 function canSaveNextTripsChunk(startExecTime, timeout) {
   const executionTimeSeconds = (new Date() - startExecTime) / 1000
@@ -45,9 +44,15 @@ async function keepOnlyNewTrips(trips, accountId) {
   return tripsToSave
 }
 
+function keepMoreRecentTripsWhenDuplicates(trips) {
+  const sortedDescending = sortBy(trips, ['startDate']).reverse()
+  return uniqBy(sortedDescending, '_id')
+}
+
 module.exports = {
   canSaveNextTripsChunk,
   restartKonnector,
   createChunks,
-  keepOnlyNewTrips
+  keepOnlyNewTrips,
+  keepMoreRecentTripsWhenDuplicates
 }

--- a/src/utils.spec.js
+++ b/src/utils.spec.js
@@ -1,6 +1,9 @@
 jest.mock('./queries.js')
 const { findSavedTripByDates } = require('./queries')
-const { keepOnlyNewTrips } = require('./utils')
+const {
+  keepOnlyNewTrips,
+  keepMoreRecentTripsWhenDuplicates
+} = require('./utils')
 
 describe('remove duplicates', () => {
   const trips = [
@@ -54,5 +57,42 @@ describe('remove duplicates', () => {
     findSavedTripByDates.mockResolvedValueOnce([])
     tripsWithoutDuplicates = await keepOnlyNewTrips(trips)
     expect(tripsWithoutDuplicates).toEqual(trips)
+  })
+
+  it('should remove oldest duplicates ', () => {
+    const tripsWithDuplicates = [
+      {
+        _id: '1',
+        startDate: '2022-01-01',
+        endDate: '2022-01-01'
+      },
+      {
+        _id: '2',
+        startDate: '2022-01-02',
+        endDate: '2022-01-02'
+      },
+      {
+        _id: '2',
+        startDate: '2022-01-01',
+        endDate: '2022-01-01'
+      },
+      {
+        _id: '2',
+        startDate: '2022-01-03',
+        endDate: '2022-01-03'
+      },
+      {
+        _id: '3',
+        startDate: '2022-01-05',
+        endDate: '2022-01-05'
+      }
+    ]
+    const noDuplicates = keepMoreRecentTripsWhenDuplicates(tripsWithDuplicates)
+    expect(noDuplicates.length).toBe(3) // or not to be
+    expect(noDuplicates[1]).toEqual({
+      _id: '2',
+      startDate: '2022-01-03',
+      endDate: '2022-01-03'
+    })
   })
 })


### PR DESCRIPTION
When fetching for manual entries, duplicates can be found when the user
edit the same trip several times.
This led to conflicts, as we were trying to save the same trip more than
once.
Hence, we detect such duplicates and only keep the more recent one.
We also now save sequentially rather than in bulk, as performance is not
critical for manual entries and it makes error messages more explicit.