### PR TITLE
fix: Log as warning instead of error when manual trip not found

### DIFF
--- a/src/save.js
+++ b/src/save.js
@@ -43,7 +43,7 @@ async function updateTripsWithManualEntries(
     )
     if (!savedTrip || savedTrip.length < 1) {
       log(
-        'error',
+        'warn',
         `No trip found for the manual entry from ${entry.data.start_fmt_time} to ${entry.data.end_fmt_time}`
       )
       continue


### PR DESCRIPTION
When an error is logged, Harvest will display an error to the user.
In this case, the user cannot do anything about it, so we prefer to
reduce the log level to a warning.