### PR TITLE
feat: Handle 500 error

### DIFF
--- a/src/run.js
+++ b/src/run.js
@@ -108,6 +108,8 @@ const run = async ({ fields, accountData, accountId }) => {
     log('error', err && err.message)
     if (err.statusCode === 403) {
       throw new Error(errors.LOGIN_FAILED)
+    } else if (err.statusCode === 500) {
+      throw new Error(`${errors.VENDOR_DOWN}.500_ERROR`)
     }
     throw new Error(errors.VENDOR_DOWN)
   }


### PR DESCRIPTION
Occasionally, the connector receives a 500 error from the trace server.
This happens when an unknown mode is found by the server. See this
issue:
https://github.com/e-mission/e-mission-docs/issues/682

To better identify this specific case, we create a new
`VENDOR_DOWN.500_ERROR` error